### PR TITLE
Fix missing line break in final course register template

### DIFF
--- a/webapp/templates/webapp/final_course_register.html
+++ b/webapp/templates/webapp/final_course_register.html
@@ -15,7 +15,7 @@
 
 <p>Pokud se nemůžete zúčastnit kurzů v plnném rozsahu, označtě to prosím ve spodní části formuláře.</p><br />
     <h2>
-        V prostorách ENKI o.p.s., Dukelská 145, Třeboň
+        V prostorách ENKI o.p.s., Dukelská 145, Třeboň<br />
         (Závěrečný kurz je zdarma.)
     </h2>
 <div class="contact-form">


### PR DESCRIPTION
Added a line break after the course location details to ensure proper formatting and readability. This improves the visual presentation of the template for end users.